### PR TITLE
ビギナーリーダーを選ぶ際にBOT自信を選ばないようにする

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+export const BOT_USER_ID = 'U01KSR3SVR7'
 export const BEGGINER_LEADER = 'U01CX9XGV61'
 export const CHANNELS = {
   BEGGINER: 'C01JL8VFDCK',

--- a/src/pick-begginer-leader.ts
+++ b/src/pick-begginer-leader.ts
@@ -1,4 +1,4 @@
-import { BEGGINER_LEADER, CHANNELS } from './config'
+import { BEGGINER_LEADER, BOT_USER_ID, CHANNELS } from './config'
 import {
   arrayAtLeastOne,
   formatDate,
@@ -9,7 +9,9 @@ import { getMembers, postMessage } from './slack-lib'
 
 export const handler = async () => {
   const members = await getMembers({ channel: CHANNELS.BEGGINER })
-  const withoutLeader = members.filter(member => member !== BEGGINER_LEADER)
+  const withoutLeader = members.filter(
+    member => member !== BEGGINER_LEADER && member !== BOT_USER_ID
+  )
   if (!arrayAtLeastOne(withoutLeader)) {
     await postMessage({
       channel: CHANNELS.BEGGINER,


### PR DESCRIPTION
# セルフチェック項目

- [ ] 新しい関数の作成
- [x] 既存の関数の修正
- [ ] `serverless.yml`の修正

# 関係者

@ycu-engine/bot-provider
